### PR TITLE
user dictionaries at ~/.local/presage; small cleanup

### DIFF
--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -21,13 +21,13 @@ public:
 
     QDBusInterface* interface() const;
 
-Q_SIGNALS:
+signals:
     void clearDataRequested();
 
-public Q_SLOTS:
+public slots:
     uint clearData();
 
-protected Q_SLOTS:
+protected slots:
     void initialize();
 
 private:

--- a/src/presagepredictor.cpp
+++ b/src/presagepredictor.cpp
@@ -282,8 +282,6 @@ void PresagePredictor::setLanguage(const QString &language)
                 return;
             }
 
-            // TODO: it might not be the best idea to hardcode the user dir here, but for SFOS it is going to be the user dir
-
             QString userdb =
                 QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) +
                 QString("/presage/lm_%1.db").arg(language.toLower());

--- a/src/presagepredictor.h
+++ b/src/presagepredictor.h
@@ -80,6 +80,8 @@ public:
 
     PresagePredictorModel *engine() const;
 
+protected:
+
     QStringList predictions() const;
     void setPredictions(const QStringList &predictions);
 


### PR DESCRIPTION
I have 

* modified destructor of PresagePredictor (lost the timer loop and deleted non-nullptr; please let me know if timer loop was needed)

* made user database path in accordance with common directory paths of current envs (.local/presage/...)

* added parent to the engine in its constructor to avoid it dangling around 

So, its mainly about memory management and I hope its not breaking anything. As far as I can see, it worked fine.