### PR TITLE
ASYNC implementation for Presage predicitons

### DIFF
--- a/presage_predictor.pro
+++ b/presage_predictor.pro
@@ -11,13 +11,15 @@ SOURCES += \
     src/presagepredictor.cpp \
     src/plugin.cpp \
     src/notificationmanager.cpp \
-    src/presagepredictormodel.cpp
+    src/presagepredictormodel.cpp \
+    src/presageworker.cpp
 
 HEADERS += \
     src/presagepredictor.h \
     src/plugin.h \
     src/notificationmanager.h \
-    src/presagepredictormodel.h
+    src/presagepredictormodel.h \
+    src/presageworker.h
 
 LIBS += -lpresage -lsqlite3 -lmarisa
 

--- a/src/presagepredictor.cpp
+++ b/src/presagepredictor.cpp
@@ -129,7 +129,7 @@ void PresagePredictor::acceptWord(const QString &word)
     emit _learnSignal(word, m_language);
 
     if (m_shiftState == ShiftLatchedByWordStart ||
-            m_shiftState == ShiftLockedByWordStart) {
+        m_shiftState == ShiftLockedByWordStart) {
         // if we have had prediction capitalization due the wordbuffer contents switch it off
         // since we have finished the word editing
         m_shiftState = NoShift;
@@ -151,7 +151,7 @@ void PresagePredictor::acceptPrediction(int index)
         }
 
         if (m_shiftState == ShiftLatchedByWordStart ||
-                m_shiftState == ShiftLockedByWordStart) {
+            m_shiftState == ShiftLockedByWordStart) {
             m_shiftState = NoShift;
             setEngineCapitalization(m_shiftState);
         }
@@ -269,7 +269,7 @@ void PresagePredictor::setShiftState(ShiftState shiftState)
     qDebug() << "PresagePredictor::setShiftState(" << QMetaEnum::fromType<ShiftState>().valueToKey(shiftState) << ")";
     if (m_shiftState != shiftState) {
         if (m_shiftState == ShiftLatched && shiftState == NoShift &&
-                m_wordBuffer.length() == 1  && m_wordBuffer.at(0).isUpper()) {
+            m_wordBuffer.length() == 1  && m_wordBuffer.at(0).isUpper()) {
             // when starting a word with latched shift with capital letter
             // sink the shiftchange to noncapital and fool the model with firstcapital mode
             m_shiftState = ShiftLatchedByWordStart;

--- a/src/presagepredictor.h
+++ b/src/presagepredictor.h
@@ -121,7 +121,7 @@ private:
 
     QStringList m_predictedWords;
     QString m_contextBuffer;
-    QString m_wordBuffer;    
+    QString m_wordBuffer;
     bool m_backspacePressed;
     int m_backspaceCounter;
     ShiftState m_shiftState;

--- a/src/presageworker.cpp
+++ b/src/presageworker.cpp
@@ -1,0 +1,114 @@
+#include "presageworker.h"
+
+#include <QtGlobal>
+#include <QFileInfo>
+#include <QStandardPaths>
+
+#include <string>
+#include <sstream>
+#include <presage.h>
+
+
+/** Callback object for presage demo application.
+ *
+ * We need to provide a callback class to allow presage to query the
+ * application's text buffer. In a real world application, this would
+ * fetch the text from whatever object stores the text composition
+ * (i.e. a GUI widget in a graphical interface)
+ *
+ * For the purpose of this demonstration program, the callback class
+ * will retrieve contextual data from a standard stringstream object.
+ *
+ */
+class PresagePredictorCallback : public PresageCallback {
+public:
+    PresagePredictorCallback(std::shared_ptr<std::string> buffer): m_buffer(buffer) { }
+
+    std::string get_past_stream() const { return *m_buffer; }
+    std::string get_future_stream() const { return empty; }
+
+public:
+    std::shared_ptr<std::string> m_buffer;
+    const std::string empty;
+};
+
+
+///////////////////////////////////
+/// Implementation of PresageWorker
+PresageWorker::PresageWorker(PresagePredictor *pmain) :
+    QObject(),
+    m_predictor(pmain)
+{
+    m_buffer.reset(new std::string);
+    m_callback.reset(new PresagePredictorCallback(m_buffer));
+    if (!m_callback)
+        return;
+
+    try {
+        m_presage.reset(new Presage(m_callback.get()));
+    } catch (PresageException e) {
+        m_presage.reset();
+        qCritical() << QString("Failed to initialize presage: ") + e.what();
+        return;
+    }
+}
+
+PresageWorker::~PresageWorker()
+{
+}
+
+void PresageWorker::predict()
+{
+    if (!m_presage || !m_presageInitialized)
+        return;
+
+    QString lang = m_language;
+    if (m_predictor->contextStream(m_last_id, lang, *m_buffer)) {
+        setLanguage(lang);
+
+        // stream was updated
+        std::vector< std::string > std_words = m_presage->predict();
+        QStringList words;
+        for (const auto &a: std_words)
+            words.append(QString::fromStdString(a));
+
+        emit predictedWords(words, m_last_id);
+    }
+}
+
+void PresageWorker::setLanguage(const QString &language)
+{
+    if (!m_presage)
+        return;
+
+    if (m_language != language) {
+        m_language = language;
+        QString dbFileName = QString("/usr/share/presage/database_%1").arg(language.toLower());
+        if (QFileInfo::exists(dbFileName)) {
+            try {
+                m_presage->config("Presage.Predictors.DefaultSmoothedNgramTriePredictor.DBFILENAME",  dbFileName.toLatin1().constData());
+            } catch (PresageException e) {
+                qCritical() << e.what();
+                return;
+            }
+
+            QString userdb =
+                QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) +
+                QString("/presage/lm_%1.db").arg(language.toLower());
+            m_presage->config("Presage.Predictors.UserSmoothedNgramPredictor.DBFILENAME",
+                              userdb.toLatin1().constData());
+            m_presageInitialized = true;
+            emit languageChanged();
+        } else {
+            m_presageInitialized = false;
+        }
+    }
+}
+
+void PresageWorker::learn(QString text, QString language)
+{
+    // learn only if the language if the same as the current one
+    if (m_language == language) {
+        m_presage->learn(text.toStdString());
+    }
+}

--- a/src/presageworker.h
+++ b/src/presageworker.h
@@ -1,0 +1,46 @@
+#ifndef PRESAGEWORKER_H
+#define PRESAGEWORKER_H
+
+#include "presagepredictor.h"
+
+#include <QObject>
+
+#include <QStringList>
+
+#include <string>
+
+#include <memory>
+#include <vector>
+#include <sstream>
+
+class Presage;
+class PresageCallback;
+
+class PresageWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit PresageWorker(PresagePredictor *pmain);
+    ~PresageWorker();
+
+signals:
+    void predictedWords(QStringList, size_t);
+    void languageChanged();
+
+public slots:
+    void setLanguage(const QString &language);
+    void predict();
+    void learn(QString text, QString language);
+
+private:
+    std::unique_ptr<PresageCallback> m_callback;
+    std::unique_ptr<Presage> m_presage;
+    PresagePredictor        *m_predictor;
+
+    bool m_presageInitialized;
+    size_t m_last_id{0};
+    QString m_language;
+    std::shared_ptr<std::string> m_buffer;
+};
+
+#endif // PRESAGEWORKER_H


### PR DESCRIPTION
This PR fixes https://github.com/martonmiklos/sailfishos-presage-predictor/issues/9 by pushing predictions into separate thread.

This PR makes a separation between linking with QML in GUI thread and Presage predictor. Presage object is created in the constructor of PresagePredictor and put by it into separate thread using Presage wrapper PresageWorker. Communication between  PresagePredictor and PresageWorker is implemented by queued signals allowing to perform predictions in asynchronous manner. 

Here,  PresagePredictor is also used as a stack which asks for new prediction and, when the worker thread is ready to do so, gives the latest request. Thus, if the worker will fall behind, it will be able to skip few predictions that are not needed anymore and perform the latest one. For this to work, language and "past buffers" are handled accordingly. 

As before, RPMs are available are at https://build.merproject.org/package/show/home:rinigus:keyboard/sailfishos-presage-predictor . For ARM devices, grab http://repo.merproject.org/obs/home:/rinigus:/keyboard/sailfish_latest_armv7hl/armv7hl/maliit-plugin-presage-1.0+async.20180227153247.ab6a779-10.22.1.jolla.armv7hl.rpm and install on the top of Marisa-based RPM to get the latest version.