### PR TITLE
Hunspell support

### DIFF
--- a/data/presage.xml
+++ b/data/presage.xml
@@ -129,7 +129,7 @@
         </DefaultRecencyPredictor>
         <DefaultHunspellPredictor>
             <PREDICTOR>HunspellPredictor</PREDICTOR>
-            <LOGGER>DEBUG</LOGGER>
+            <LOGGER>ERROR</LOGGER>
             <AFFIX>/usr/share/hunspell/en_US.aff</AFFIX>
             <DICTIONARY>/usr/share/hunspell/en_US.dic</DICTIONARY>
             <!-- fixed probability assigned to prediction -->

--- a/data/presage.xml
+++ b/data/presage.xml
@@ -130,9 +130,9 @@
         <DefaultHunspellPredictor>
             <PREDICTOR>HunspellPredictor</PREDICTOR>
             <LOGGER>ERROR</LOGGER>
-            <AFFIX>/usr/share/hunspell/en_US.aff</AFFIX>
-            <DICTIONARY>/usr/share/hunspell/en_US.dic</DICTIONARY>
-            <!-- fixed probability assigned to prediction -->
+            <!-- basename of the dictionary and affix files. extensions .dic and .aff will be added, as appropriate -->
+            <DICTIONARYBASE>/usr/share/hunspell/en_US</DICTIONARYBASE>
+            <!-- the probability assigned to the first prediction -->
             <PROBABILITY>0.000001</PROBABILITY>
         </DefaultHunspellPredictor>
     </Predictors>

--- a/data/presage.xml
+++ b/data/presage.xml
@@ -5,7 +5,7 @@
         <!-- PREDICTORS
 	     Space separated list of predictors to use to generate predictions
         -->
-        <PREDICTORS>DefaultSmoothedNgramTriePredictor UserSmoothedNgramPredictor DefaultRecencyPredictor</PREDICTORS>
+        <PREDICTORS>DefaultSmoothedNgramTriePredictor UserSmoothedNgramPredictor DefaultHunspellPredictor DefaultRecencyPredictor</PREDICTORS>
     </PredictorRegistry>
     <ContextTracker>
         <LOGGER>ERROR</LOGGER>
@@ -127,5 +127,13 @@
             <N_0>1</N_0>
             <CUTOFF_THRESHOLD>20</CUTOFF_THRESHOLD>
         </DefaultRecencyPredictor>
+        <DefaultHunspellPredictor>
+            <PREDICTOR>HunspellPredictor</PREDICTOR>
+            <LOGGER>DEBUG</LOGGER>
+            <AFFIX>/usr/share/hunspell/en_US.aff</AFFIX>
+            <DICTIONARY>/usr/share/hunspell/en_US.dic</DICTIONARY>
+            <!-- fixed probability assigned to prediction -->
+            <PROBABILITY>0.000001</PROBABILITY>
+        </DefaultHunspellPredictor>
     </Predictors>
 </Presage>

--- a/presage_predictor.pro
+++ b/presage_predictor.pro
@@ -23,6 +23,9 @@ HEADERS += \
 
 LIBS += -lpresage -lsqlite3 -lmarisa
 
+CONFIG += link_pkgconfig
+PKGCONFIG += hunspell
+
 DISTFILES += qmldir \
     rpm/PresagePredictor.yaml \
     qml/PresageInputHandler.qml \

--- a/rpm/maliit-plugin-presage.spec
+++ b/rpm/maliit-plugin-presage.spec
@@ -30,6 +30,7 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(sqlite3)
 BuildRequires:  libpresage-devel
 BuildRequires:  libmarisa-devel
+BuildRequires:  hunspell-devel >= 1.5.1
 Obsoletes:   presage-data
 
 %description

--- a/rpm/maliit-plugin-presage.yaml
+++ b/rpm/maliit-plugin-presage.yaml
@@ -31,6 +31,7 @@ PkgConfigBR:
 PkgBR:
   - libpresage-devel
   - libmarisa-devel
+  - hunspell-devel >= 1.5.1
 
 # Runtime dependencies which are not automatically detected
 Requires:

--- a/src/presagepredictor.cpp
+++ b/src/presagepredictor.cpp
@@ -27,6 +27,7 @@ PresagePredictor::PresagePredictor(QQuickItem *parent):
     connect(this, &PresagePredictor::_predictSignal, worker, &PresageWorker::predict, Qt::QueuedConnection);
     connect(this, &PresagePredictor::_learnSignal, worker, &PresageWorker::learn, Qt::QueuedConnection);
     connect(worker, &PresageWorker::predictedWords, this, &PresagePredictor::onPredictedWords, Qt::QueuedConnection);
+    connect(worker, &PresageWorker::languageChanged, this, &PresagePredictor::languageChanged, Qt::QueuedConnection);
 
     m_workerThread.start();
 

--- a/src/presageworker.cpp
+++ b/src/presageworker.cpp
@@ -99,6 +99,15 @@ void PresageWorker::setLanguage(const QString &language)
             m_presage->config("Presage.Predictors.UserSmoothedNgramPredictor.DBFILENAME",
                               userdb.toLatin1().constData());
             m_presageInitialized = true;
+
+            // Hunspell support. Set even if the files are absent - hunspell will just be returning nothing
+            QString affix = "/usr/share/hunspell/" + m_language + ".aff";
+            QString dict = "/usr/share/hunspell/" + m_language + ".dic";
+            m_presage->config("Presage.Predictors.DefaultHunspellPredictor.AFFIX",
+                              affix.toLatin1().constData());
+            m_presage->config("Presage.Predictors.DefaultHunspellPredictor.DICTIONARY",
+                              dict.toLatin1().constData());
+
             emit languageChanged();
         } else {
             m_presageInitialized = false;

--- a/src/presageworker.cpp
+++ b/src/presageworker.cpp
@@ -83,7 +83,8 @@ void PresageWorker::setLanguage(const QString &language)
 
     if (m_language != language) {
         m_language = language;
-        QString dbFileName = QString("/usr/share/presage/database_%1").arg(language.toLower());
+        qDebug() << "Language: " << m_language;
+        QString dbFileName = QString("/usr/share/presage/database_%1").arg(m_language);
         if (QFileInfo::exists(dbFileName)) {
             try {
                 m_presage->config("Presage.Predictors.DefaultSmoothedNgramTriePredictor.DBFILENAME",  dbFileName.toLatin1().constData());
@@ -94,7 +95,7 @@ void PresageWorker::setLanguage(const QString &language)
 
             QString userdb =
                 QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) +
-                QString("/presage/lm_%1.db").arg(language.toLower());
+                QString("/presage/lm_%1.db").arg(m_language);
             m_presage->config("Presage.Predictors.UserSmoothedNgramPredictor.DBFILENAME",
                               userdb.toLatin1().constData());
             m_presageInitialized = true;

--- a/src/presageworker.cpp
+++ b/src/presageworker.cpp
@@ -101,12 +101,9 @@ void PresageWorker::setLanguage(const QString &language)
             m_presageInitialized = true;
 
             // Hunspell support. Set even if the files are absent - hunspell will just be returning nothing
-            QString affix = "/usr/share/hunspell/" + m_language + ".aff";
-            QString dict = "/usr/share/hunspell/" + m_language + ".dic";
-            m_presage->config("Presage.Predictors.DefaultHunspellPredictor.AFFIX",
-                              affix.toLatin1().constData());
-            m_presage->config("Presage.Predictors.DefaultHunspellPredictor.DICTIONARY",
-                              dict.toLatin1().constData());
+            QString hunspell_base = "/usr/share/hunspell/" + m_language;
+            m_presage->config("Presage.Predictors.DefaultHunspellPredictor.DICTIONARYBASE",
+                              hunspell_base.toLatin1().constData());
 
             emit languageChanged();
         } else {

--- a/utils/keyboard/keyboard-presage-XX.spec
+++ b/utils/keyboard/keyboard-presage-XX.spec
@@ -17,6 +17,7 @@ URL: https://github.com/martonmiklos/sailfishos-presage-predictor
 Source: %{name}-%{version}.tar.xz
 BuildArch: noarch
 Requires: presage-lang-__langcode__
+Requires: hunspell-lang-__langcode__
 Requires: maliit-plugin-presage
 
 %description

--- a/utils/keyboard/package-keyboard.sh
+++ b/utils/keyboard/package-keyboard.sh
@@ -8,7 +8,7 @@ if [ "$#" -ne 5 ]; then
     echo "Usage: $0 Language langcode version keyboard.qml keyboard.conf"
     echo
     echo "Language: Specify language in English starting with the capital letter, ex 'Estonian'"
-    echo "langcode: Specify language two-letter code, ex 'et'"
+    echo "langcode: Specify language code, ex 'en_US'. Use the same notation as Hunspell dictionaries."
     echo "version: Version of the language package, ex '1.0.0'"
     echo "keyboard.qml: Keyboard QML file"
     echo "keyboard.conf: Keyboard Configuration file referencing the QML file"


### PR DESCRIPTION
I am ready to submit the next PR. This one adds support for Hunspell predictor. This has been the latest change I did in Presage and now its hooked to the plugin as well.

Few important changes:

* Compared to the earlier, language specification used in all package names and keyboard `languageCode` follows Hunspell notation: en_US , hu_HU, sv_SE, et_EE . This has to be followed in our configurations

* Presage uses up-to-date hunspell that makes its usage more C++ like. I have submitted corresponding PR to Mer core, let's see if/when it gets upstream. For know, you could use hunspell packages in my OBS 

As before, RPMs are available are at https://build.merproject.org/package/show/home:rinigus:keyboard/sailfishos-presage-predictor . All languages that we test with are covered in terms of n-grams (Swedish is using the latest version from OpenRepos RPM) and hunspell dictionaries. Keyboards for SWE and HUN are missing, those you have to hack together yourself.

Enjoy!