### PR TITLE
Fix ru keyboard compatibility with  SFOS 4.5

### DIFF
--- a/keyboard/ru-presage.qml
+++ b/keyboard/ru-presage.qml
@@ -96,11 +96,11 @@ KeyboardLayout {
         CharacterKey {
             caption: "-"
             captionShifted: "-"
-            implicitWidth: punctuationKeyWidthNarrow
+            implicitWidth: punctuationKeyWidth
             fixedWidth: !splitActive
         }
         ContextAwareCommaKey {
-            implicitWidth: punctuationKeyWidthNarrow
+            implicitWidth: punctuationKeyWidth
         }
         SpacebarKey {}
         SpacebarKey {
@@ -110,7 +110,7 @@ KeyboardLayout {
         CharacterKey {
             caption: "."
             captionShifted: "."
-            implicitWidth: punctuationKeyWidthNarrow
+            implicitWidth: punctuationKeyWidth
             fixedWidth: !splitActive
             separator: SeparatorState.HiddenSeparator
         }


### PR DESCRIPTION
I'm getting this on Sailfish OS 4.5.0.18

```
Nov 07 06:14:54 Xperia10II-DualSIM invoker[12260]: WARNING: file:///usr/share/maliit/plugins/com/jolla/layouts/ru-presage.qml:113: ReferenceError: punctuationKeyWidthNarrow is not defined
Nov 07 06:14:54 Xperia10II-DualSIM invoker[12260]: WARNING: file:///usr/share/maliit/plugins/com/jolla/layouts/ru-presage.qml:103: ReferenceError: punctuationKeyWidthNarrow is not defined
Nov 07 06:14:54 Xperia10II-DualSIM invoker[12260]: WARNING: file:///usr/share/maliit/plugins/com/jolla/layouts/ru-presage.qml:99: ReferenceError: punctuationKeyWidthNarrow is not defined
```

and  punctuation keys get squeezed so that they can't really be pressed. With these changes the punctuation keys become usable.

Don't know if `punctuationKeyWidth` is defined in earlier versions of Sailfish OS. It is still defined in Sailfish OS 5.0.0.71